### PR TITLE
Prove that there are Scala 3 libraries that don't break with case classes like PureConfig does

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .bsp
 .metals
 .vscode
-target/
+target

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # sandbox
 
 ```
-+personNew/mimaReportBinaryIssues
+++3.* personNew/mimaReportBinaryIssues
+++3.* appOld/run
+++3.* appNew/run
 ```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # sandbox
+
+```
++personNew/mimaReportBinaryIssues
+```

--- a/app/src/main/scala-2/AppVersionSpecific.scala
+++ b/app/src/main/scala-2/AppVersionSpecific.scala
@@ -1,0 +1,7 @@
+import pureconfig._
+import pureconfig.generic.semiauto._
+
+trait AppVersionSpecific {
+  implicit def personReader: ConfigReader[Person] =
+    deriveReader
+}

--- a/app/src/main/scala-3/AppVersionSpecific.scala
+++ b/app/src/main/scala-3/AppVersionSpecific.scala
@@ -1,0 +1,7 @@
+import pureconfig._
+import pureconfig.generic.derivation.default._
+
+trait AppVersionSpecific {
+  implicit def personReader: ConfigReader[Person] =
+    ConfigReader.derived[Person]
+}

--- a/app/src/main/scala/App.scala
+++ b/app/src/main/scala/App.scala
@@ -1,7 +1,11 @@
 import pureconfig._
+import upickle.default._
 
 object App extends AppVersionSpecific {
+
   def main(args: Array[String]): Unit = {
-    println(ConfigSource.string("{ name = foo }").load[Person])
+    val string = """{ "name": "foo" }"""
+    println(ConfigSource.string(string).load[Person])
+    println(read[Person](string))
   }
 }

--- a/app/src/main/scala/App.scala
+++ b/app/src/main/scala/App.scala
@@ -1,10 +1,7 @@
 import pureconfig._
-import pureconfig.generic.derivation.default._
 
-object App {
-  implicit def personReader: ConfigReader[Person] = ConfigReader.derived[Person]
-
+object App extends AppVersionSpecific {
   def main(args: Array[String]): Unit = {
-    println(ConfigSource.string("{ name = foo }").load[Person])
+    println(ConfigSource.string("{ name = foo, age = 1 }").load[Person])
   }
 }

--- a/app/src/main/scala/App.scala
+++ b/app/src/main/scala/App.scala
@@ -2,6 +2,6 @@ import pureconfig._
 
 object App extends AppVersionSpecific {
   def main(args: Array[String]): Unit = {
-    println(ConfigSource.string("{ name = foo, age = 1 }").load[Person])
+    println(ConfigSource.string("{ name = foo }").load[Person])
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -17,10 +17,16 @@ val crossSettings = List(
 )
 
 lazy val personOld = project
+  .settings(
+    scalacOptions += "-Ymacro-annotations",
+    libraryDependencies += "com.lihaoyi" %% "upickle" % "3.1.0"
+  )
   .settings(crossSettings)
 lazy val personNew = project
   .settings(crossSettings)
   .settings(
+    scalacOptions += "-Ymacro-annotations",
+    libraryDependencies += "com.lihaoyi" %% "upickle" % "3.1.0",
     mimaPreviousClassfiles := Map(
       projectID.value -> (personOld / Compile / classDirectory).value
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -1,20 +1,56 @@
-ThisBuild / scalaVersion := "3.2.2"
+val Scala213 = "2.13.10"
+val Scala3 = "3.2.2"
+
+ThisBuild / scalaVersion := Scala3
+
+lazy val root = project
+  .in(file("."))
+  .aggregate(
+    personOld,
+    personNew,
+    appOld,
+    appNew
+  )
+
+val crossSettings = List(
+  crossScalaVersions := List(scalaVersion.value, Scala213)
+)
 
 lazy val personOld = project
-lazy val personNew = project.settings(
-  mimaPreviousClassfiles := Map(
-    projectID.value -> (personOld / Compile / classDirectory).value
-  ),
-  mimaReportBinaryIssues :=
-    mimaReportBinaryIssues
-      .dependsOn(personOld / Compile / compile)
-      .value
-)
+  .settings(crossSettings)
+lazy val personNew = project
+  .settings(crossSettings)
+  .settings(
+    mimaPreviousClassfiles := Map(
+      projectID.value -> (personOld / Compile / classDirectory).value
+    ),
+    mimaReportBinaryIssues :=
+      mimaReportBinaryIssues
+        .dependsOn(personOld / Compile / compile)
+        .value
+  )
 
 val appSettings = Seq(
   Compile / unmanagedSourceDirectories += (LocalRootProject / baseDirectory).value / "app" / "src" / "main" / "scala",
-  libraryDependencies += "com.github.pureconfig" %% "pureconfig-core" % "0.17.3"
+  Compile / unmanagedSourceDirectories += {
+    if (scalaVersion.value == Scala3)
+      (LocalRootProject / baseDirectory).value / "app" / "src" / "main" / "scala-3"
+    else
+      (LocalRootProject / baseDirectory).value / "app" / "src" / "main" / "scala-2"
+  },
+  libraryDependencies += {
+    if (scalaVersion.value == Scala3)
+      "com.github.pureconfig" %% "pureconfig-core" % "0.17.3"
+    else
+      "com.github.pureconfig" %% "pureconfig" % "0.17.3"
+  }
 )
 
-val appOld = project.dependsOn(personOld).settings(appSettings)
-val appNew = project.dependsOn(personNew).settings(appSettings)
+val appOld = project
+  .dependsOn(personOld)
+  .settings(crossSettings)
+  .settings(appSettings)
+val appNew = project
+  .dependsOn(personNew)
+  .settings(crossSettings)
+  .settings(appSettings)

--- a/personNew/src/main/scala-2/PersonVersionSpecific.scala
+++ b/personNew/src/main/scala-2/PersonVersionSpecific.scala
@@ -1,0 +1,5 @@
+import upickle.default._
+
+trait PersonVersionSpecific {
+  implicit lazy val reader: ReadWriter[Person] = macroRW
+}

--- a/personNew/src/main/scala-3/PersonVersionSpecific.scala
+++ b/personNew/src/main/scala-3/PersonVersionSpecific.scala
@@ -1,0 +1,5 @@
+import upickle.default._
+
+trait PersonVersionSpecific {
+  implicit lazy val reader: ReadWriter[Person] = ReadWriter.derived
+}

--- a/personNew/src/main/scala/Person.scala
+++ b/personNew/src/main/scala/Person.scala
@@ -1,5 +1,5 @@
 case class Person private (name: String, age: Int) {
-  def this(name: String) = this(name, -1)
+  private def this(name: String) = this(name, -1)
 
   def withName(name: String): Person = copy(name = name)
   def withAge(age: Int): Person = copy(age = age)
@@ -17,8 +17,11 @@ object Person {
 
   def fromProduct(p: Product): Person =
     p.productArity match {
-      case 1 => Person(p.productElement(0).asInstanceOf[String])
-      case _ =>
+      case 1 =>
+        Person(
+          p.productElement(0).asInstanceOf[String]
+        )
+      case 2 =>
         Person(
           p.productElement(0).asInstanceOf[String],
           p.productElement(1).asInstanceOf[Int]

--- a/personNew/src/main/scala/Person.scala
+++ b/personNew/src/main/scala/Person.scala
@@ -1,4 +1,4 @@
-case class Person private (name: String, age: Int) {
+case class Person private (name: String, age: Int = -1) {
   private def this(name: String) = this(name, -1)
 
   def withName(name: String): Person = copy(name = name)
@@ -9,7 +9,7 @@ case class Person private (name: String, age: Int) {
 }
 
 object Person {
-  def apply(name: String, age: Int): Person = new Person(name, age)
+  def apply(name: String, age: Int = -1): Person = new Person(name, age)
 
   def apply(name: String): Person = new Person(name)
 

--- a/personNew/src/main/scala/Person.scala
+++ b/personNew/src/main/scala/Person.scala
@@ -1,5 +1,5 @@
-case class Person private (name: String, age: Int = -1) {
-  private def this(name: String) = this(name, -1)
+case class Person private[Person] (name: String, age: Int = -1) {
+  private[Person] def this(name: String) = this(name, -1)
 
   def withName(name: String): Person = copy(name = name)
   def withAge(age: Int): Person = copy(age = age)
@@ -8,9 +8,9 @@ case class Person private (name: String, age: Int = -1) {
     new Person(name, age)
 }
 
-object Person {
+object Person extends PersonVersionSpecific {
+  // causes bug in uPickle's Scala 2 derivation macro, need to comment both `apply`
   def apply(name: String, age: Int = -1): Person = new Person(name, age)
-
   def apply(name: String): Person = new Person(name)
 
   private def unapply(person: Person): Some[Person] = Some(person)
@@ -18,10 +18,12 @@ object Person {
   def fromProduct(p: Product): Person =
     p.productArity match {
       case 1 =>
+        println("XXX new, case 1")
         Person(
           p.productElement(0).asInstanceOf[String]
         )
       case 2 =>
+        println("XXX new, case 2")
         Person(
           p.productElement(0).asInstanceOf[String],
           p.productElement(1).asInstanceOf[Int]

--- a/personOld/src/main/scala-2/PersonVersionSpecific.scala
+++ b/personOld/src/main/scala-2/PersonVersionSpecific.scala
@@ -1,0 +1,5 @@
+import upickle.default._
+
+trait PersonVersionSpecific {
+  implicit lazy val reader: ReadWriter[Person] = macroRW
+}

--- a/personOld/src/main/scala-3/PersonVersionSpecific.scala
+++ b/personOld/src/main/scala-3/PersonVersionSpecific.scala
@@ -1,0 +1,5 @@
+import upickle.default._
+
+trait PersonVersionSpecific {
+  implicit lazy val reader: ReadWriter[Person] = ReadWriter.derived
+}

--- a/personOld/src/main/scala/Person.scala
+++ b/personOld/src/main/scala/Person.scala
@@ -1,14 +1,18 @@
-case class Person private (name: String) {
+case class Person private[Person] (name: String) {
   def withName(name: String): Person = copy(name = name)
 
   private def copy(name: String = this.name): Person =
     new Person(name)
 }
 
-object Person {
+object Person extends PersonVersionSpecific {
   def apply(name: String): Person = new Person(name)
   private def unapply(person: Person): Some[Person] = Some(person)
   def fromProduct(p: Product): Person = p.productArity match {
-    case 1 => Person(p.productElement(0).asInstanceOf[String])
+    case 1 =>
+      println("XXX old, case 1")
+      Person(
+        p.productElement(0).asInstanceOf[String]
+      )
   }
 }

--- a/personOld/src/main/scala/Person.scala
+++ b/personOld/src/main/scala/Person.scala
@@ -8,4 +8,7 @@ case class Person private (name: String) {
 object Person {
   def apply(name: String): Person = new Person(name)
   private def unapply(person: Person): Some[Person] = Some(person)
+  def fromProduct(p: Product): Person = p.productArity match {
+    case 1 => Person(p.productElement(0).asInstanceOf[String])
+  }
 }


### PR DESCRIPTION
Unlike PureConfig, uPickle doesn't have issues with picking up default values and thus can successfully decode old values

Try running
```
++3.* personNew/mimaReportBinaryIssues
++3.* appOld/run
++3.* appNew/run
```
/cc @armanbilge 